### PR TITLE
timetypes: Prevent errant value creation with non-RFC3339 formatted strings

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-20230804-145749.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20230804-145749.yaml
@@ -1,0 +1,7 @@
+kind: BREAKING CHANGES
+body: 'timetypes: The `NewRFC3339Value` and `NewRFC3339PointerValue` functions now
+  return `diag.Diagnostics` so an error diagnostic can be raised if the string is 
+  not RFC3339 formatted'
+time: 2023-08-04T14:57:49.413035-04:00
+custom:
+  Issue: "7"

--- a/.changes/unreleased/ENHANCEMENTS-20230804-150017.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230804-150017.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'timetypes: Added `NewRFC3339ValueMust` and `NewRFC3339PointerValueMust` value
+  creation functions, which panic if the string is not RFC3339 formatted'
+time: 2023-08-04T15:00:17.549012-04:00
+custom:
+  Issue: "7"

--- a/timetypes/diagnostics.go
+++ b/timetypes/diagnostics.go
@@ -1,0 +1,17 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package timetypes
+
+import "github.com/hashicorp/terraform-plugin-framework/diag"
+
+// rfc3339InvalidStringDiagnostic returns an error diagnostic intended to report
+// when a string is not RFC3339 format.
+func rfc3339InvalidStringDiagnostic(value string, err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		"Invalid RFC3339 String Value",
+		"A string value was provided that is not valid RFC3339 string format.\n\n"+
+			"Given Value: "+value+"\n"+
+			"Error: "+err.Error(),
+	)
+}

--- a/timetypes/rfc3339_type.go
+++ b/timetypes/rfc3339_type.go
@@ -89,13 +89,7 @@ func (t RFC3339Type) Validate(ctx context.Context, in tftypes.Value, path path.P
 	}
 
 	if _, err := time.Parse(time.RFC3339, valueString); err != nil {
-		diags.AddAttributeError(
-			path,
-			"Invalid RFC3339 String Value",
-			"A string value was provided that is not valid RFC3339 string format.\n\n"+
-				"Given Value: "+valueString+"\n"+
-				"Error: "+err.Error(),
-		)
+		diags.Append(diag.WithPath(path, rfc3339InvalidStringDiagnostic(valueString, err)))
 
 		return diags
 	}

--- a/timetypes/rfc3339_type_test.go
+++ b/timetypes/rfc3339_type_test.go
@@ -116,7 +116,7 @@ func TestRFC3339TypeValueFromTerraform(t *testing.T) {
 	}{
 		"true": {
 			in:          tftypes.NewValue(tftypes.String, "2023-07-25T20:43:16+00:00"),
-			expectation: timetypes.NewRFC3339Value("2023-07-25T20:43:16+00:00"),
+			expectation: timetypes.NewRFC3339ValueMust("2023-07-25T20:43:16+00:00"),
 		},
 		"unknown": {
 			in:          tftypes.NewValue(tftypes.String, tftypes.UnknownValue),

--- a/timetypes/rfc3339_value_example_test.go
+++ b/timetypes/rfc3339_value_example_test.go
@@ -18,7 +18,7 @@ func ExampleRFC3339_ValueRFC3339Time() {
 	// For example purposes, typically the data model would be populated automatically by Plugin Framework via Config, Plan or State.
 	// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
 	data := TimeResourceModel{
-		Timestamp: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
+		Timestamp: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
 	}
 
 	// Check that the RFC3339 data is known and able to be converted to time.Time

--- a/timetypes/rfc3339_value_test.go
+++ b/timetypes/rfc3339_value_test.go
@@ -25,47 +25,47 @@ func TestRFC3339_StringSemanticEquals(t *testing.T) {
 		expectedDiags      diag.Diagnostics
 	}{
 		"not equal - different dates": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-26T23:43:16Z"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-26T23:43:16Z"),
 			expectedMatch:      false,
 		},
 		"not equal - different times": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T23:01:16Z"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T23:01:16Z"),
 			expectedMatch:      false,
 		},
 		"not equal - different offset times": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T23:43:16+03:00"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16+03:00"),
 			expectedMatch:      false,
 		},
 		"not equal - UTC time and local time": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T20:43:16-03:00"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T20:43:16-03:00"),
 			expectedMatch:      false,
 		},
 		"semantically equal - Z suffix and positive zero num offset": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T23:43:16+00:00"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16+00:00"),
 			expectedMatch:      true,
 		},
 		"semantically equal - Z suffix and negative zero num offset": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T23:43:16-00:00"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16-00:00"),
 			expectedMatch:      true,
 		},
 		"semantically equal - negative zero and positive zero num offset": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16-00:00"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T23:43:16+00:00"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16-00:00"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16+00:00"),
 			expectedMatch:      true,
 		},
 		"semantically equal - byte for byte match": {
-			currentRFC3339time: timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
-			givenRFC3339time:   timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
+			givenRFC3339time:   timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
 			expectedMatch:      true,
 		},
 		"error - not given RFC3339 value": {
-			currentRFC3339time: timetypes.NewRFC3339Value("0000-00-00T00:00:00-00:00"),
+			currentRFC3339time: timetypes.NewRFC3339ValueMust("0000-00-00T00:00:00-00:00"),
 			givenRFC3339time:   basetypes.NewStringValue("0000-00-00T00:00:00-00:00"),
 			expectedMatch:      false,
 			expectedDiags: diag.Diagnostics{
@@ -124,15 +124,15 @@ func TestRFC3339_ValueRFC3339Time(t *testing.T) {
 			},
 		},
 		"valid RFC3339 Timestamp - Zulu suffix": {
-			RFC3339:           timetypes.NewRFC3339Value("2023-07-25T23:43:16Z"),
+			RFC3339:           timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16Z"),
 			expectedTimestamp: "2023-07-25T23:43:16Z",
 		},
 		"valid RFC3339 Timestamp - UTC offset ": {
-			RFC3339:           timetypes.NewRFC3339Value("2023-07-25T23:43:16-00:00"),
+			RFC3339:           timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16-00:00"),
 			expectedTimestamp: "2023-07-25T23:43:16-00:00",
 		},
 		"valid RFC3339 Timestamp - EDT offset ": {
-			RFC3339:           timetypes.NewRFC3339Value("2023-07-25T23:43:16-04:00"),
+			RFC3339:           timetypes.NewRFC3339ValueMust("2023-07-25T23:43:16-04:00"),
 			expectedTimestamp: "2023-07-25T23:43:16-04:00",
 		},
 	}


### PR DESCRIPTION
Closes #7

Since `StringValue` is exported as part of the type embedding, its still possible to create errant values, but this should cover most expected provider developer usage. The `...Must` value creation functions are debatable, since we want to discourage situations that could potentially cause panics in provider logic, however this is a pragmatic compromise similar to the addition of `...Must` value creation functions for some of the framework base types.