### PR TITLE
Chore: golangci-lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -19,7 +19,7 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting

--- a/timetypes/go_duration_type_test.go
+++ b/timetypes/go_duration_type_test.go
@@ -39,7 +39,7 @@ func TestDurationTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/timetypes/go_duration_value_test.go
+++ b/timetypes/go_duration_value_test.go
@@ -48,7 +48,7 @@ func TestDuration_Equals(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -98,7 +98,7 @@ func TestDurationValidateAttribute(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -154,7 +154,7 @@ func TestDurationValidateParameter(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -216,7 +216,7 @@ func TestDuration_StringSemanticEquals(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -265,7 +265,7 @@ func TestDuration_ValueDuration(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/timetypes/rfc3339_type_test.go
+++ b/timetypes/rfc3339_type_test.go
@@ -39,7 +39,7 @@ func TestRFC3339TypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/timetypes/rfc3339_value_test.go
+++ b/timetypes/rfc3339_value_test.go
@@ -83,7 +83,7 @@ func TestRFC3339_StringSemanticEquals(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,7 +172,7 @@ func TestRFC3339ValidateAttribute(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -259,7 +259,7 @@ func TestRFC3339ValidateParameter(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -320,7 +320,7 @@ func TestRFC3339_ValueRFC3339Time(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
- Replace `max-per-linter` with `max-issues-per-linters`
- Replace `exportloopref` linter with `copyloopvar`
- Replace `tenv` linter with `usetesting`